### PR TITLE
Add support for OPTIONS request

### DIFF
--- a/jsonapi_mock_server/base_metadata.py
+++ b/jsonapi_mock_server/base_metadata.py
@@ -1,0 +1,22 @@
+from collections import OrderedDict
+
+from rest_framework.metadata import SimpleMetadata
+
+class MockServerMetadata(SimpleMetadata):
+    def determine_metadata(self, request, view):
+        metadata = OrderedDict()
+        metadata['name'] = view.get_view_name()
+        metadata['description'] = view.get_view_description()
+        metadata['renders'] = [renderer.media_type for renderer in view.renderer_classes]
+        metadata['parses'] = [parser.media_type for parser in view.parser_classes]
+        metadata['allowed_methods'] = view.allowed_methods
+        metadata['actions'] = self.determine_actions(request, view)
+        return {'data': metadata}
+
+    def determine_actions(self, request, view):
+        actions = {}
+        action_data = view.get_action_metadata()
+        actions['POST'] = action_data
+        actions['PUT'] = action_data
+
+        return actions

--- a/jsonapi_mock_server/base_models.py
+++ b/jsonapi_mock_server/base_models.py
@@ -1,17 +1,37 @@
+from collections import OrderedDict
 import copy
+import inflection
 import os
+
+from jsonapi_mock_server import settings
+from utils import upper_camelize_resource
 
 
 class BaseResource(object):
     resource_type = ""
     attributes = {}
     fake_attributes = {}
+    attribute_metadata = {}
+    relationship_metadata = {}
     # The json_api_rules attribute provides a hook from resource to JsonAPIBuilder,
     # allowing us to specify exceptions or special rules to apply when creating
     # a particular JsonAPI resource object.
     json_api_rules = []
     relationships = []
-    page_size = int(os.environ.get('DEFAULT_PAGE_SIZE'))
+    page_size = settings.MS_PAGE_SIZE
+
+    type_lookup = {
+        str: "String",
+        type(None): "String",
+        int: "Integer",
+        bool: "Boolean",
+    }
+
+    relation_type_lookup = {
+        tuple: "ManyToMany",
+        int: "OneToMany",
+        str: "OneToMany",
+    }
 
     def get_attributes(self):
         return copy.deepcopy(self.attributes)
@@ -21,6 +41,43 @@ class BaseResource(object):
         for attribute, fake in self.fake_attributes.iteritems():
             fake_attributes[attribute] = fake.generate_value()
         return fake_attributes
+
+    def get_field_label(self, attribute):
+        return inflection.titleize(attribute)
+
+    def get_action_metadata(self):
+        attributes = {}
+        for fieldname, value in self.attributes.iteritems():
+            field_info = OrderedDict()
+            field_info['type'] = self.type_lookup[type(value)]
+            field_info['required'] = False
+            field_info['read_only'] = False
+            field_info['label'] = self.get_field_label(fieldname)
+
+            field_metadata = self.attribute_metadata.get(fieldname, {})
+            field_info.update(field_metadata)
+
+            attributes[inflection.underscore(fieldname)] = field_info
+
+        for relationship in self.relationships:
+            fieldname, value = relationship
+
+            field_info = OrderedDict()
+            field_info['initial'] = []
+            field_info['type'] = 'Relationship'
+            field_info['relationship_type'] = self.relation_type_lookup[type(value)]
+            field_info['relationship_resource'] = upper_camelize_resource(fieldname)
+            field_info['allows_include'] = True
+            field_info['required'] = False
+            field_info['read_only'] = False
+            field_info['label'] = self.get_field_label(fieldname)
+
+            field_metadata = self.relationship_metadata.get(fieldname, {})
+            field_info.update(field_metadata)
+
+            attributes[inflection.underscore(fieldname)] = field_info
+
+        return attributes
 
     def find_relationship_id(related_type):
         for relationship in self.relationships:

--- a/jsonapi_mock_server/base_views.py
+++ b/jsonapi_mock_server/base_views.py
@@ -7,7 +7,7 @@ from rest_framework import viewsets
 
 from hooks import MockServerHookParser
 from json_api_builder import JsonAPIErrorBuilder, JsonAPIResourceDetailBuilder, JsonAPIResourceListBuilder
-from mock_server import settings
+from jsonapi_mock_server import settings
 
 
 class MockServerBaseViewSet(viewsets.ViewSet):
@@ -31,6 +31,8 @@ class MockServerBaseViewSet(viewsets.ViewSet):
 
 
 class ResourceDetailViewSet(MockServerBaseViewSet):
+    allowed_methods = ['GET', 'PATCH', 'DELETE', 'OPTIONS']
+
     def retrieve(self, request, pk):
         resource_id = pk
         overrides = MockServerHookParser(request, self.attributes).parse_hooks()
@@ -84,6 +86,8 @@ class ResourceDetailViewSet(MockServerBaseViewSet):
 
 
 class ResourceListViewSet(MockServerBaseViewSet):
+    allowed_methods = ['GET', 'POST', 'OPTIONS']
+
     def list(self, request):
         overrides = MockServerHookParser(request, self.attributes).parse_hooks()
 
@@ -186,4 +190,4 @@ class ResourceListViewSet(MockServerBaseViewSet):
 
 
 class ResourceViewSet(ResourceListViewSet, ResourceDetailViewSet):
-    pass
+    allowed_methods = ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS']

--- a/jsonapi_mock_server/settings.py
+++ b/jsonapi_mock_server/settings.py
@@ -27,3 +27,4 @@ MIDDLEWARE_CLASSES = [
     'corsheaders.middleware.CorsMiddleware',
 ]
 MS_DEFAULT_LIST_LENGTH = 10
+MS_PAGE_SIZE = 10

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
 setup(
     name='jsonapi-mock-server',
     description='JSON API mock server',
-    version='0.4',
+    version='0.5',
     author='ZeroCater',
     packages=find_packages(),
     install_requires=install_requires,


### PR DESCRIPTION
Adds support for `OPTIONS` requests in the same style as [Django REST Framework](http://www.django-rest-framework.org/api-guide/metadata/) and the [DRF JSON API](https://github.com/django-json-api/django-rest-framework-json-api/blob/develop/rest_framework_json_api/metadata.py) libraries.