### PR TITLE
Refactor base tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
 setup(
     name='jsonapi-mock-server',
     description='JSON API mock server',
-    version='0.7',
+    version='0.8',
     author='ZeroCater',
     packages=find_packages(),
     install_requires=install_requires,


### PR DESCRIPTION
* Include default `test_detail_view` and `test_list_view` tests for every viewset, to reduce duplicating code
* If detail view resource id returns a 404, try to find a valid resource id
* Skip detail/list test if viewset does not support that endpoint